### PR TITLE
fix: unable to use with unix pipes

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function codeImport(options = {}) {
         ? parseInt(res.groups.from, 10)
         : undefined;
       const toLine = res.groups.to ? parseInt(res.groups.to, 10) : undefined;
-      const fileAbsPath = path.resolve(file.dirname, filePath);
+      const fileAbsPath = path.resolve(file.dirname || ".", filePath);
 
       if (options.async) {
         promises.push(

--- a/test.js
+++ b/test.js
@@ -92,3 +92,23 @@ test('File import using single line number and following lines', () => {
     "
   `);
 });
+
+
+test('File from STDIN', () => {
+  expect(
+    remark()
+      .use(codeImport, {})
+      .processSync({
+        contents: input('#L2-'),
+        path: { ...path.resolve('test.md'), dirname: undefined },
+      })
+      .toString()
+  ).toMatchInlineSnapshot(`
+    "\`\`\`js file=./__fixtures__/say-#-hi.js#L2-
+    console.log('This is another line...');
+    console.log('This is the last line');
+    console.log('Oops, here is another');
+    \`\`\`
+    "
+  `);
+});


### PR DESCRIPTION
Plugin fails when using input from a pipe instead of (presumably a file). This is because it seems to require a path.

This patch will remove the requirement for a path, but use it when it's there

For reference, a pipeline which fails with previous code is shown below:

```
const unified = require('unified');
const createStream = require('unified-stream');
const parse = require('remark-parse');
const gfm = require('remark-gfm');
const remark2rehype = require('remark-rehype');
const stringifyRehype = require('rehype-stringify');
const remarkCodeImport = require('remark-code-import');
const raw = require('rehype-raw');

const processor = unified()
  .use(parse)
  .use(gfm)
  .use(remarkCodeImport)
  .use(remark2rehype, {allowDangerousHtml: true})
  .use(raw)
  .use(stringifyRehype);

process.stdin.pipe(createStream(processor)).pipe(process.stdout);
```