### PR TITLE
Create a version which can use snippetId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "remark-code-import",
+  "name": "@johnrom/remark-code-import",
   "description": "📝 Populate code blocks from files",
-  "version": "0.3.0",
+  "version": "0.4.0-beta1",
   "main": "index.js",
   "author": "Kai Hao",
   "license": "MIT",
@@ -21,6 +21,7 @@
     "code-fence",
     "file-system",
     "import-code",
+    "code-snippets",
     "gatsby",
     "gatsby-plugin"
   ],


### PR DESCRIPTION
Usage:

### Source file:

```tsx
// @snippet:start yolo-snippet
const yolo = () => alert('yolo');
// @snippet:end
```

### Markdown file:

````
```tsx file=./your-file.tsx@yolo-snippet
```
````

## Additional info.

- End snippet supports ids as well, like `@snippet:end yolo-snippet`. Could be useful for mixing using multiple snippets on a page, maybe??
- Adds a basePath option to the plugin, so `file=./path.tsx` can be based from somewhere else than the markdown document.