### PR TITLE
Accept `basePath` option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,49 +13,6 @@ function extractLines(content, fromLine, hasDash, toLine) {
   return lines.slice(start - 1, end).join('\n');
 }
 
-const anyEndRegex = `^\\s*// @snippet:end\\s*$`;
-
-function extractSnippet(content, snippetId) {
-  if (typeof snippetId === "undefined" || typeof content === "undefined") {
-    return content;
-  }
-
-  // alphanumeric, dashes and underscores
-  // otherwise, no match!
-  if (!snippetId.match(/[A-Za-z0-9-_]+/)) {
-    return "";
-  }
-
-  const startRegex = `^\\s*// @snippet:start ${snippetId}\\s*$`;
-  const endRegex = `^\\s*// @snippet:end ${snippetId}\\s*$`;
-
-  const snippetStart = content.search(new RegExp(startRegex, "im"));
-
-  // there must be a beginning
-  if (snippetStart === -1) {
-    throw new Error(`Unable to locate snippet: ${snippetId}`);
-  }
-
-  let snippet = content.substr(snippetStart);
-
-  let snippetEnd = snippet.search(new RegExp(endRegex, "im"));
-
-  // if no end for `snippetId`, check for one without an ID
-  if (snippetEnd === -1) {
-    snippetEnd = snippet.search(new RegExp(anyEndRegex, "im"))
-  }
-
-  // if we found an end, slice it
-  if (snippetEnd !== -1) {
-    snippet = snippet.substr(0, snippetEnd);
-  }
-
-  const lines = snippet.split(EOL);
-
-  // remove @snippet:start and trailing newline
-  return lines.slice(1, lines.length - 1).join('\n');
-}
-
 function codeImport(options = {}) {
   return function transformer(tree, file) {
     const codes = [];
@@ -73,7 +30,8 @@ function codeImport(options = {}) {
       if (!fileMeta) {
         continue;
       }
-      const res = /^file=(?<path>.+?)(?:(?:#(?:L(?<from>\d+)(?<dash>-)?)?)(?:L(?<to>\d+))?|(?:@(?<snippetId>\S+)))?$/.exec(
+
+      const res = /^file=(?<path>.+?)(?:(?:#(?:L(?<from>\d+)(?<dash>-)?)?)(?:L(?<to>\d+))?)?$/.exec(
         fileMeta
       );
       if (!res || !res.groups || !res.groups.path) {
@@ -85,22 +43,12 @@ function codeImport(options = {}) {
         ? parseInt(res.groups.from, 10)
         : undefined;
       const toLine = res.groups.to ? parseInt(res.groups.to, 10) : undefined;
-      const snippetId = res.groups.snippetId;
 
       if (!options.basePath && !file.dirname) {
         throw new Error("Unable to parse base file path. Please configure options.basePath or modify your tooling to include path data, like mdxOptions.filepath.")
       }
 
       const fileAbsPath = path.resolve(options.basePath || file.dirname, filePath);
-
-      const extractText = (fileContent) => snippetId
-        ? extractSnippet(fileContent, snippetId)
-        : extractLines(
-          fileContent,
-          fromLine,
-          hasDash,
-          toLine
-        ).trim();
 
       if (options.async) {
         promises.push(
@@ -111,8 +59,12 @@ function codeImport(options = {}) {
                 return;
               }
 
-              node.value = extractText(fileContent);
-
+              node.value = extractLines(
+                fileContent,
+                fromLine,
+                hasDash,
+                toLine
+              ).trim();
               resolve();
             });
           })
@@ -120,7 +72,12 @@ function codeImport(options = {}) {
       } else {
         const fileContent = fs.readFileSync(fileAbsPath, 'utf8');
 
-        node.value = extractText(fileContent);
+        node.value = extractLines(
+          fileContent,
+          fromLine,
+          hasDash,
+          toLine
+        ).trim();
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "remark-code-import",
+  "name": "@johnrom/remark-code-import",
   "description": "📝 Populate code blocks from files",
-  "version": "0.3.0",
+  "version": "0.4.0-beta1",
   "main": "index.js",
   "author": "Kai Hao",
   "license": "MIT",
@@ -21,6 +21,7 @@
     "code-fence",
     "file-system",
     "import-code",
+    "code-snippets",
     "gatsby",
     "gatsby-plugin"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@johnrom/remark-code-import",
+  "name": "remark-code-import",
   "description": "📝 Populate code blocks from files",
-  "version": "0.4.0-beta1",
+  "version": "0.3.0",
   "main": "index.js",
   "author": "Kai Hao",
   "license": "MIT",
@@ -21,7 +21,6 @@
     "code-fence",
     "file-system",
     "import-code",
-    "code-snippets",
     "gatsby",
     "gatsby-plugin"
   ],

--- a/test.js
+++ b/test.js
@@ -1,9 +1,21 @@
 const codeImport = require('./');
 const remark = require('remark');
 const path = require('path');
+const os = require('os');
 
 const input = q => `
 \`\`\`js file=./__fixtures__/say-#-hi.js${q}
+\`\`\`
+`;
+
+const basePathTestPath = path.resolve(process.cwd(), 'gatsby');
+const basePathTestInput = q => `
+\`\`\`js file=../__fixtures__/say-#-hi.js${q}
+\`\`\`
+`;
+
+const absolutePathTestInput = q => `
+\`\`\`js file=${path.normalize(process.cwd())}/__fixtures__/say-#-hi.js${q}
 \`\`\`
 `;
 
@@ -25,6 +37,60 @@ test('Basic file import', () => {
     \`\`\`
     "
   `);
+});
+
+test('Absolute file import', () => {
+  expect(
+    remark()
+      .use(codeImport, {})
+      .processSync({
+        contents: absolutePathTestInput(''),
+        path: path.resolve('test.md'),
+      })
+      .toString()
+  ).toBe(`\`\`\`js file=${path.normalize(process.cwd())}/__fixtures__/say-#-hi.js
+console.log('Hello remark-code-import!');${os.EOL}console.log('This is another line...');${os.EOL}console.log('This is the last line');${os.EOL}console.log('Oops, here is another');
+\`\`\`
+`);
+});
+
+test('Basic file import with basePath', () => {
+  expect(
+    remark()
+      .use(codeImport, {
+        basePath: basePathTestPath,
+      })
+      .processSync({
+        contents: basePathTestInput(''),
+        path: path.resolve('test.md'),
+      })
+      .toString()
+  ).toMatchInlineSnapshot(`
+    "\`\`\`js file=../__fixtures__/say-#-hi.js
+    console.log('Hello remark-code-import!');
+    console.log('This is another line...');
+    console.log('This is the last line');
+    console.log('Oops, here is another');
+    \`\`\`
+    "
+  `);
+});
+
+test('Absolute file import with basePath', () => {
+  expect(
+    remark()
+      .use(codeImport, {
+        basePath: basePathTestPath,
+      })
+      .processSync({
+        contents: absolutePathTestInput(''),
+        path: path.resolve('test.md'),
+      })
+      .toString()
+  ).toBe(`\`\`\`js file=${path.normalize(process.cwd())}/__fixtures__/say-#-hi.js
+console.log('Hello remark-code-import!');${os.EOL}console.log('This is another line...');${os.EOL}console.log('This is the last line');${os.EOL}console.log('Oops, here is another');
+\`\`\`
+`);
 });
 
 test('File import using line numbers', () => {


### PR DESCRIPTION
This allows you to specify a base path where all of your markdown files can source code from. This allows documentation to remain maintainable by not worrying about where within the docs you are sourcing code from.

Supersedes #11 

Example: 

### The filesystem

```
my-app/
  content/
    guides/
      advanced/
        my-advanced-example.md
    my-example.md
  src/
    my-script.js
  remark-plugins.js
```

### `remark-plugins.js`

```js
const plugins = [
  {
    resolve: 'remark-code-import',
    options: {
      async: true,
      basePath: '.',
    },
  },
];
```

### `my-example.md` OR `guides/advanced/my-advanced-example.md`

````md
```js file=./src/my-script.js
```
````

As you can see, it adds less overhead for documentation maintenance to be able to use a base path from which to source file content.  Now I can rename the directories and move documents around without concern of breaking the documentation.